### PR TITLE
Allow to use 0-30 C setpoint range with schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Danfoss Ally Home Assistant automations & scripts
 Danfoss Ally eTRV automations and scripts for Home Assistant using [Zigbee2MQTT](https://www.zigbee2mqtt.io/). Tested to work with firmware v1.28(00.28.0008 00.28).
 
+# Updating
+The blueprints can be updated by importing them again overwriting the existing one. NOTE! Your existing script might not have input values in correct format. Best to remove any values in YAML editing view. Major version number (=v1.x.x) will be updated in this case.
+
 # Time updater automation
 ![version](https://img.shields.io/badge/version-1.2.2-blue?style=plastic)
 
@@ -12,13 +15,12 @@ Danfoss Ally has no knowledge of the current time. Zigbee coordinator must send 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fussaka%2FDanfoss-Ally-HA-automations%2Freleases%2Fdownload%2Ftime-updater-v1.2.2%2Fdanfoss_ally_time_updater.yaml)
 
 # Weekly schedule script
-![version](https://img.shields.io/badge/version-1.0.0-blue?style=plastic)
+![version](https://img.shields.io/badge/version-2.0.0-blue?style=plastic)
 
 ### Note!
 - The weekly schedule is lost after power cycle or OTA or error state.
-- HA DST start helper will convert set time to the new local time. E.g. 31/03/2024 03:00 --> 31/03/2024 04:00. For now fix by setting the time minute before DST start time e.g. 02:59.
 
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fussaka%2FDanfoss-Ally-HA-automations%2Freleases%2Ftag%2Fset-schedule-v1.0.0)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fussaka%2FDanfoss-Ally-HA-automations%2Freleases%2Fdownload%2Fset-schedule-v2.0.0)
 
 # External temperature sensor automation
 [Blueprint](https://community.home-assistant.io/t/zigbee2mqtt-danfoss-ally-send-external-temperature-to-trv-version-2/627564/8)
@@ -28,6 +30,3 @@ Automatically adjust eTRV's own temperature with offset. The external temperatur
 
 ### Radiator covered = true
 Rely only for the external temperature. The external temperature needs to be send at least every 30 minutes but no more often than every 5 minutes @ every 0,1K change.
-
-# Support
-[![Buy_me_a_coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-black?style=social&logo=buy-me-a-coffee&logoColor=black&link=https%3A%2F%2Fwww.buymeacoffee.com%2Fussaka)](https://www.buymeacoffee.com/ussaka)

--- a/scripts/danfoss_ally_set_schedule.yaml
+++ b/scripts/danfoss_ally_set_schedule.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: >
     ## Danfoss Ally set weekly schedule
 
-    **Version: 1.0.0**  
+    **Version: 2.0.0**  
 
 
     Set Danfoss Ally eTRV's weekly schedule with z2m.  
@@ -38,7 +38,6 @@ blueprint:
           mode: list
     ally_trv:
       name: Ally eTRV
-      description: Device name must match with IEEE address
       selector:
         device:
           entity:
@@ -46,15 +45,15 @@ blueprint:
                 - climate
           multiple: false
     transition1_setpoint:
-      name: Transition 1 heat set point
+      name: Transition 1 target temperature
       selector:
         number:
-          min: 15
-          max: 25
+          min: 0
+          max: 30
           unit_of_measurement: °C
           mode: box
     transition1_time:
-      name: Transition 1 time
+      name: Transition 1 trigger time
       selector:
         number:
           min: 0
@@ -62,15 +61,15 @@ blueprint:
           unit_of_measurement: Minutes since midnight
           mode: box
     transition2_setpoint:
-      name: Transition 2 heat set point
+      name: Transition 2 target temperature
       selector:
         number:
-          min: 15
-          max: 25
+          min: 0
+          max: 30
           unit_of_measurement: °C
           mode: box
     transition2_time:
-      name: Transition 2 time
+      name: Transition 2 trigger time
       selector:
         number:
           min: 0
@@ -78,15 +77,15 @@ blueprint:
           unit_of_measurement: Minutes since midnight
           mode: box          
     transition3_setpoint:
-      name: Transition 3 heat set point
+      name: Transition 3 target temperature
       selector:
         number:
-          min: 15
-          max: 25
+          min: 0
+          max: 30
           unit_of_measurement: °C
           mode: box
     transition3_time:
-      name: Transition 3 time
+      name: Transition 3 trigger time
       selector:
         number:
           min: 0
@@ -94,15 +93,15 @@ blueprint:
           unit_of_measurement: Minutes since midnight
           mode: box
     transition4_setpoint:
-      name: Transition 4 heat set point
+      name: Transition 4 target temperature
       selector:
         number:
-          min: 15
-          max: 25
+          min: 0
+          max: 30
           unit_of_measurement: °C
           mode: box
     transition4_time:
-      name: Transition 4 time
+      name: Transition 4 trigger time
       selector:
         number:
           min: 0
@@ -110,15 +109,15 @@ blueprint:
           unit_of_measurement: Minutes since midnight
           mode: box 
     transition5_setpoint:
-      name: Transition 5 heat set point
+      name: Transition 5 target temperature
       selector:
         number:
-          min: 15
-          max: 25
+          min: 0
+          max: 30
           unit_of_measurement: °C
           mode: box
     transition5_time:
-      name: Transition 5 time
+      name: Transition 5 trigger time
       selector:
         number:
           min: 0
@@ -126,15 +125,15 @@ blueprint:
           unit_of_measurement: Minutes since midnight
           mode: box
     transition6_setpoint:
-      name: Transition 6 heat set point
+      name: Transition 6 target temperature
       selector:
         number:
-          min: 15
-          max: 25
+          min: 0
+          max: 30
           unit_of_measurement: °C
           mode: box
     transition6_time:
-      name: Transition 6 time
+      name: Transition 6 trigger time
       selector:
         number:
           min: 0


### PR DESCRIPTION
- modified: allow to set schedule with target temperature between 0-30°C range
- modified: prepare readme for set-schedule-v2.0.0